### PR TITLE
remove reference to incorrect license in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ related: ["related-item-1", "related-item-2"]
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+See the [LICENSE](LICENSE) file for details.
 
 ## 🙏 Acknowledgments
 


### PR DESCRIPTION
# Pull Request

## Description

I noticed there was some leftover text in the README referring to a specific license that is not what we have in the LICENSE.md file. So just a small edit.

