### PR TITLE
Fix cards page title

### DIFF
--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -3,7 +3,7 @@ status: "stable"
 last_updated: "2025-09-25"
 ---
 
-# Cards Guidance
+# Cards
 
 Cards are containers used to group content together. They allow the user to view information and take actions.
 


### PR DESCRIPTION
Fixes #158

Changes the cards component page title from 'Cards Guidance' to 'Cards' for consistency with other component pages.