### PR TITLE
Fix auto-PR workflow to use Personal Access Token

### DIFF
--- a/.github/automated-maintenance.md
+++ b/.github/automated-maintenance.md
@@ -169,6 +169,34 @@ git push origin aurora-agent/fix-issue-161
 
 ## Configuration
 
+### Prerequisites: Personal Access Token
+
+The auto-PR workflow requires a Personal Access Token (PAT) because organization policies may prevent the default `GITHUB_TOKEN` from creating pull requests.
+
+**Setup Steps:**
+
+1. **Create a Personal Access Token:**
+   - Go to GitHub: **Settings → Developer settings → Personal access tokens → Tokens (classic)**
+   - Click **"Generate new token (classic)"**
+   - Name: `Aurora Agent PR Creator` (or similar)
+   - Permissions needed:
+     - ✅ `repo` (full control of private repositories)
+     - ✅ `workflow` (update GitHub Actions workflows)
+   - Set expiration (recommend 90 days or 1 year)
+   - Click **Generate token**
+   - **Copy the token immediately** (you won't see it again!)
+
+2. **Add Token as Repository Secret:**
+   - Go to repository: **Settings → Secrets and variables → Actions**
+   - Click **"New repository secret"**
+   - Name: `AURORA_AGENT_TOKEN`
+   - Value: Paste your token
+   - Click **Add secret**
+
+3. **Token Renewal:**
+   - When the token expires, generate a new one and update the repository secret
+   - The workflow will fail with authentication errors if the token is expired
+
 ### GitHub Action Files
 
 **Issue Analysis:** `.github/workflows/issue-analysis.yml`
@@ -220,17 +248,20 @@ To adjust the automation:
 
 ## Getting Started
 
-1. **Enable GitHub Actions** (if not already enabled)
-2. **Run first analysis:**
+1. **Set up Personal Access Token:**
+   - Follow the [Prerequisites: Personal Access Token](#prerequisites-personal-access-token) instructions above
+   - This is **required** for the auto-PR workflow to function
+2. **Enable GitHub Actions** (if not already enabled)
+3. **Run first analysis:**
    - Go to Actions → "Automated Issue Analysis"
    - Click "Run workflow"
-3. **Review analysis issue** and identify 1-2 AI-suitable issues
-4. **Test the workflow:**
+4. **Review analysis issue** and identify 1-2 AI-suitable issues
+5. **Test the workflow:**
    - Use LLM to implement changes for one issue
    - Create `aurora-agent/fix-issue-{NUMBER}` branch
    - Push and verify PR is created automatically
-5. **Review and merge** the test PR
-6. **Scale up** to more issues as confidence grows
+6. **Review and merge** the test PR
+7. **Scale up** to more issues as confidence grows
 
 ## Questions?
 

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'aurora-agent/**'
 
+# Note: This workflow requires a Personal Access Token (PAT) to be set as a repository secret
+# named AURORA_AGENT_TOKEN with 'repo' and 'workflow' permissions.
+# This is necessary because organization policies may prevent GITHUB_TOKEN from creating PRs.
+
 permissions:
   contents: read
   pull-requests: write
@@ -33,7 +37,7 @@ jobs:
       - name: Check if PR already exists
         id: check-pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AURORA_AGENT_TOKEN }}
         run: |
           BRANCH_NAME="${{ steps.extract-issue.outputs.branch_name }}"
           PR_EXISTS=$(gh pr list --head "$BRANCH_NAME" --json number --jq 'length')
@@ -43,7 +47,7 @@ jobs:
         if: steps.check-pr.outputs.exists == '0' && steps.extract-issue.outputs.issue_number != ''
         id: issue-details
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AURORA_AGENT_TOKEN }}
         run: |
           ISSUE_NUM="${{ steps.extract-issue.outputs.issue_number }}"
 
@@ -69,7 +73,7 @@ jobs:
       - name: Create Pull Request
         if: steps.check-pr.outputs.exists == '0'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AURORA_AGENT_TOKEN }}
         run: |
           ISSUE_NUM="${{ steps.extract-issue.outputs.issue_number }}"
           BRANCH_NAME="${{ steps.extract-issue.outputs.branch_name }}"


### PR DESCRIPTION
## Summary

Fixes the auto-PR workflow which was failing with permission errors due to organization policies preventing `GITHUB_TOKEN` from creating pull requests.

## Changes

### Workflow Update (`.github/workflows/auto-pr.yml`)
- Replace all instances of `secrets.GITHUB_TOKEN` with `secrets.AURORA_AGENT_TOKEN`
- Add comment explaining PAT requirement
- Workflow now uses a Personal Access Token for PR creation

### Documentation Update (`.github/automated-maintenance.md`)
- Add comprehensive "Prerequisites: Personal Access Token" section
- Step-by-step instructions for creating PAT with correct permissions
- Instructions for adding token as repository secret
- Update "Getting Started" to highlight PAT setup as first step
- Include token renewal guidance

## Testing

After merging this PR and setting up the PAT:

1. Create a Personal Access Token with `repo` and `workflow` permissions
2. Add it as repository secret named `AURORA_AGENT_TOKEN`
3. Re-run the failed workflow from `aurora-agent/fix-issue-146` branch
4. Verify PR is created successfully

## Related

- Discovered during testing of #171
- Addresses the permission error: "GitHub Actions is not permitted to create or approve pull requests"