### PR TITLE
Simplify issue list format to use GitHub auto-linking

### DIFF
--- a/.github/workflows/issue-analysis.yml
+++ b/.github/workflows/issue-analysis.yml
@@ -27,8 +27,8 @@ jobs:
           ISSUE_COUNT=$(gh issue list --state open --json number --jq 'length')
           echo "count=$ISSUE_COUNT" >> $GITHUB_OUTPUT
 
-          # Get issue list with links
-          ISSUE_LIST=$(gh issue list --state open --json number,title,url --jq '.[] | "- #\(.number): [\(.title)](\(.url))"' | head -50)
+          # Get issue list (GitHub will auto-link issue numbers)
+          ISSUE_LIST=$(gh issue list --state open --json number --jq '.[] | "- #\(.number)"' | head -50)
           echo "ISSUE_LIST<<EOF" >> $GITHUB_OUTPUT
           echo "$ISSUE_LIST" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fixes the 'double links' issue in automated analysis reports where issue numbers were being displayed redundantly.

## Problem

The issue list was rendering like:
- #170: [Knocking out issues](url) → Knocking out issues

This created double/redundant links because GitHub automatically expands  to a full linked issue title.

## Solution

Simplified the issue list to just:
- #123

GitHub's auto-linking handles the rest, creating clean, single links.

## Changes

- Updated  line 31
- Changed from: `jq '.[] | "- #\(.number): [\(.title)](\(.url))"`
- Changed to: `jq '.[] | "- #\(.number)"`

## Testing

After merging, the next manual or scheduled analysis run will show clean issue lists with single links.